### PR TITLE
Fix GET request body handling

### DIFF
--- a/src/webview/components/TopBar.tsx
+++ b/src/webview/components/TopBar.tsx
@@ -107,8 +107,10 @@ export default function () {
             data: {
                 uri: bru.http?.url,
                 init: {
-                    "method": bru?.http?.method.toUpperCase(),
-                    "body": bru?.http?.method != "get" && bru?.http?.body && bru.body && bru.body[bru.http.body],
+                    method: bru?.http?.method.toUpperCase(),
+                    body: bru?.http?.method !== "get"
+                        ? bru?.http?.body && bru.body && bru.body[bru.http.body]
+                        : undefined,
                     headers: bru.headers?.filter(h => h.enabled).map(({ name, value }) => [name, value])
                 } as RequestInit
             }


### PR DESCRIPTION
## Summary
- avoid sending a boolean `false` as body on GET requests

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68408d4d8edc83309eeef1e52d8a56b1